### PR TITLE
Resource Filtering

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -49,7 +49,10 @@ jbossDeploymentStructure {
     } 
             
     resource 'my-library.jar'
-    resource path: 'lib/ext-library.jar', physicalCodeSource: true
+    resource(path: 'lib/ext-library.jar', physicalCodeSource: true) { //Configure resource filter
+        include 'api/query'
+        exclude 'api/info'
+    }
 
     subdeployments { // Configure additional subdeployments
         'my-war.war' {

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -57,10 +57,6 @@ jbossDeploymentStructure {
             exclude 'excluded.module'
 
             resource 'my-war.war'
-            resourceFilter { //Configure resource filter
-                include 'lib/api'
-                exclude 'lib/util'
-            }
         }
     }
 }

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -50,11 +50,17 @@ jbossDeploymentStructure {
             
     resource 'my-library.jar'
     resource path: 'lib/ext-library.jar', physicalCodeSource: true
-    
+
     subdeployments { // Configure additional subdeployments
         'my-war.war' {
             dependency 'another.module'
             exclude 'excluded.module'
+
+            resource 'my-war.war'
+            resourceFilter { //Configure resource filter
+                include 'lib/api'
+                exclude 'lib/util'
+            }
         }
     }
 }

--- a/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
+++ b/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
@@ -305,10 +305,6 @@ class JBossDeploymentStructureIntSpec extends IntegrationSpec {
                     exclude 'excluded.module'
                     
                     resource 'my-war.war'
-                    resourceFilter { //Configure resource filter
-                        include 'lib/api'
-                        exclude 'lib/util'
-                    }
                 }
             }
         }'''

--- a/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
+++ b/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
@@ -303,12 +303,17 @@ class JBossDeploymentStructureIntSpec extends IntegrationSpec {
                 'my-war.war' {
                     dependency 'another.module'
                     exclude 'excluded.module'
+                    
+                    resource 'my-war.war'
+                    resourceFilter { //Configure resource filter
+                        include 'lib/api'
+                        exclude 'lib/util'
+                    }
                 }
             }
         }'''
         when:
         ExecutionResult result = runTasks(CreateJBossDeploymentStructureTask.TASK_NAME)
-        file('carsten.txt').text = file('build/createJBossDeploymentStructure/jboss-deployment-structure.xml').text
         then:
         result.failure == null
         fileIsValidForSchema(file('build/createJBossDeploymentStructure/jboss-deployment-structure.xml'))

--- a/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
+++ b/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
@@ -297,7 +297,10 @@ class JBossDeploymentStructureIntSpec extends IntegrationSpec {
                 }
             }
             resource 'my-library.jar'
-            resource path: 'lib/ext-library.jar', physicalCodeSource: true
+            resource(path: 'lib/ext-library.jar', physicalCodeSource: true) { //Configure resource filter
+                include 'api/query'
+                exclude 'api/info'
+            }
             
             subdeployments { // Configure additional subdeployments
                 'my-war.war' {

--- a/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
+++ b/src/integTest/groovy/com/github/mamohr/gradle/deploymentstructure/JBossDeploymentStructureIntSpec.groovy
@@ -296,7 +296,7 @@ class JBossDeploymentStructureIntSpec extends IntegrationSpec {
                     include 'ext'
                 }
             }
-            resource 'my-library.jar\'
+            resource 'my-library.jar'
             resource path: 'lib/ext-library.jar', physicalCodeSource: true
             
             subdeployments { // Configure additional subdeployments
@@ -308,7 +308,7 @@ class JBossDeploymentStructureIntSpec extends IntegrationSpec {
         }'''
         when:
         ExecutionResult result = runTasks(CreateJBossDeploymentStructureTask.TASK_NAME)
-
+        file('carsten.txt').text = file('build/createJBossDeploymentStructure/jboss-deployment-structure.xml').text
         then:
         result.failure == null
         fileIsValidForSchema(file('build/createJBossDeploymentStructure/jboss-deployment-structure.xml'))

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/ConfigurablePathSet.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/ConfigurablePathSet.groovy
@@ -1,12 +1,17 @@
-package com.github.mamohr.gradle.deploymentstructure.model;
-
+package com.github.mamohr.gradle.deploymentstructure.model
 /**
  * Created by cschmidt on 22.02.2017.
  */
-class ConfigurablePathSet {
+class ConfigurablePathSet implements XmlSerializable {
 
-    LinkedHashSet<String> includedPaths = []
-    LinkedHashSet<String> excludedPaths = []
+    final String xmlNodeName
+
+    final LinkedHashSet<String> includedPaths = []
+    final LinkedHashSet<String> excludedPaths = []
+
+    ConfigurablePathSet(String nodeName) {
+        this.xmlNodeName = nodeName
+    }
 
     void include(String path) {
         includedPaths.add(path)
@@ -20,4 +25,14 @@ class ConfigurablePathSet {
         includedPaths.empty && excludedPaths.empty
     }
 
+    def saveToXml(Node root) {
+        Node node = new Node(root, xmlNodeName)
+
+        includedPaths.each { String path ->
+            new Node(node, 'include', [path: path])
+        }
+        excludedPaths.each { String path ->
+            new Node(node, 'exclude', [path: path])
+        }
+    }
 }

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/DependencyModule.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/DependencyModule.groovy
@@ -31,16 +31,14 @@ class DependencyModule extends Module {
     boolean optional
     boolean annotations
 
-    ConfigurablePathSet imports
-    ConfigurablePathSet exports
+    final ConfigurablePathSet imports = new ConfigurablePathSet('imports')
+    final ConfigurablePathSet exports = new ConfigurablePathSet('exports')
 
     DispositionType services
     DispositionType metaInf
 
     DependencyModule(String name) {
         super(name)
-        imports = new ConfigurablePathSet()
-        exports = new ConfigurablePathSet()
     }
 
     void imports(@DelegatesTo(ConfigurablePathSet) Closure cl) {
@@ -74,28 +72,12 @@ class DependencyModule extends Module {
             module.attributes().'meta-inf' = metaInf.name().toLowerCase()
         }
         if(!imports.empty) {
-            Node importsTag = new Node(module, 'imports')
-            appendPathSetToNode(importsTag, imports)
+            imports.saveToXml(module)
         }
         if(!exports.empty) {
-            Node exportsTag = new Node(module, 'exports')
-            appendPathSetToNode(exportsTag, exports)
+            exports.saveToXml(module)
         }
         return module
-    }
-
-    /**
-     * Appends the elements of the ConfigurablePathSet as &lt;include&gt; or &lt;exclude&gt; tag
-     * @param filterNode
-     * @param pathSet
-     */
-    protected void appendPathSetToNode(Node filterNode, ConfigurablePathSet pathSet) {
-        pathSet.includedPaths.each { String path ->
-            new Node(filterNode, 'include', [path: path])
-        }
-        pathSet.excludedPaths.each { String path ->
-            new Node(filterNode, 'exclude', [path: path])
-        }
     }
 
 }

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
@@ -62,6 +62,10 @@ class Deployment {
         resource(new Resource(path, physicalSourceCode))
     }
 
+    void resource(Map args) {
+        resource((String) args.get('path'), (Boolean) args.get('physicalCodeSource'))
+    }
+
     void resource(Resource resource) {
         resources.add(resource)
     }

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
@@ -56,10 +56,10 @@ class Deployment {
      * Adds a resource to the deployment.
      *
      * @param path Path to the resource
-     * @param physicalSourceCode Specifies wheter resource should be looked up from physical source or not
+     * @param physicalCodeSource Specifies wheter resource should be looked up from physical source or not
      */
-    void resource(String path, Boolean physicalSourceCode, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
-        resource(new Resource(path, physicalSourceCode), cl)
+    void resource(String path, Boolean physicalCodeSource, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        resource(new Resource(path, physicalCodeSource), cl)
     }
 
     void resource(String path, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
@@ -74,7 +74,7 @@ class Deployment {
         resources.add(resource)
 
         if(cl) {
-            cl.delegate = resource.filter
+            cl.delegate = resource.pathFilter
             cl.resolveStrategy = Closure.DELEGATE_FIRST
             cl()
         }

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
@@ -58,16 +58,26 @@ class Deployment {
      * @param path Path to the resource
      * @param physicalSourceCode Specifies wheter resource should be looked up from physical source or not
      */
-    void resource(String path, Boolean physicalSourceCode = false) {
-        resource(new Resource(path, physicalSourceCode))
+    void resource(String path, Boolean physicalSourceCode, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        resource(new Resource(path, physicalSourceCode), cl)
     }
 
-    void resource(Map args) {
-        resource((String) args.get('path'), (Boolean) args.get('physicalCodeSource'))
+    void resource(String path, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        resource(path, false, cl)
     }
 
-    void resource(Resource resource) {
+    void resource(Map args, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        resource((String) args.get('path'), (Boolean) args.get('physicalCodeSource'), cl)
+    }
+
+    void resource(Resource resource, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
         resources.add(resource)
+
+        if(cl) {
+            cl.delegate = resource.filter
+            cl.resolveStrategy = Closure.DELEGATE_FIRST
+            cl()
+        }
     }
 
     /***

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Deployment.groovy
@@ -58,7 +58,7 @@ class Deployment {
      * @param path Path to the resource
      * @param physicalSourceCode Specifies wheter resource should be looked up from physical source or not
      */
-    void resource(String path, Boolean physicalSourceCode) {
+    void resource(String path, Boolean physicalSourceCode = false) {
         resource(new Resource(path, physicalSourceCode))
     }
 

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructure.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructure.groovy
@@ -23,8 +23,9 @@ class JBossDeploymentStructure implements XmlSerializable {
 
     public static final String EXTENSION_NAME = "jbossDeploymentStructure"
 
-    private Set<Module> globalExcludes = []
+    @Delegate
     private Deployment deployment = new Deployment()
+    private Set<Module> globalExcludes = []
     private final NamedDomainObjectContainer<Subdeployment> subdeployments
     private List<Action<NamedDomainObjectContainer<Subdeployment>>> subdeploymentActions = new ArrayList<>();
     private List<Action<? super Node>> xmlActions = []
@@ -40,40 +41,6 @@ class JBossDeploymentStructure implements XmlSerializable {
     void globalExclude(String moduleIdentifier) {
         Module excludedModule = new Module(moduleIdentifier)
         globalExcludes.add(excludedModule)
-    }
-
-    void dependency(String moduleIdentifier) {
-        deployment.dependency(moduleIdentifier)
-    }
-
-    void dependency(String moduleIdentifier, Closure closure) {
-        deployment.dependency(moduleIdentifier, closure)
-    }
-
-    void exclude(String moduleIdentifier) {
-        deployment.exclude(moduleIdentifier)
-    }
-
-    void excludeSubSystem(String subSIdentifier) {
-        deployment.excludeSubSystem(subSIdentifier)
-    }
-
-    /**
-     * Adds a resource to the deployment.
-     *
-     * @param path Path to the resource
-     * @param physicalCodeSource Specifies wheter resource should be looked up from physical source or not
-     */
-    void resource(String path, Boolean physicalCodeSource, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
-        deployment.resource(path, physicalCodeSource, cl)
-    }
-
-    void  resource(String path, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
-        resource(path, false, cl)
-    }
-
-    void resource(Map args, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
-        resource((String) args.get('path'), (Boolean) args.get('physicalCodeSource'), cl)
     }
 
     void addSubdeployments(Collection<? extends Subdeployment> subdeployments) {

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructure.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructure.groovy
@@ -58,12 +58,22 @@ class JBossDeploymentStructure implements XmlSerializable {
         deployment.excludeSubSystem(subSIdentifier)
     }
 
-    void resource(String path, Boolean physicalCodeSource = false) {
-        deployment.resource(path, physicalCodeSource)
+    /**
+     * Adds a resource to the deployment.
+     *
+     * @param path Path to the resource
+     * @param physicalCodeSource Specifies wheter resource should be looked up from physical source or not
+     */
+    void resource(String path, Boolean physicalCodeSource, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        deployment.resource(path, physicalCodeSource, cl)
     }
 
-    void resource(Map args) {
-        resource((String) args.get('path'), (Boolean) args.get('physicalCodeSource'))
+    void  resource(String path, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        resource(path, false, cl)
+    }
+
+    void resource(Map args, @DelegatesTo(ConfigurablePathSet) Closure cl = null) {
+        resource((String) args.get('path'), (Boolean) args.get('physicalCodeSource'), cl)
     }
 
     void addSubdeployments(Collection<? extends Subdeployment> subdeployments) {

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
@@ -7,6 +7,8 @@ class Resource implements XmlSerializable {
     String path
     Boolean physicalSourceCode
 
+    ConfigurablePathSet filter = new ConfigurablePathSet()
+
     Resource(String path, Boolean physicalSourceCode) {
         this.path = path
         this.physicalSourceCode = physicalSourceCode

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
@@ -16,11 +16,10 @@ class Resource implements XmlSerializable {
 
     @Override
     def saveToXml(Node root) {
-        Map attributes = [path: path]
-        Node node = new Node(root, 'resource-root', attributes)
+        Node node = new Node(root, 'resource-root', [path: path])
 
         if (physicalSourceCode) {
-            attributes.'use-physical-code-source' = true
+            node.attributes().'use-physical-code-source' = true
         }
 
         if(!pathFilter.empty) {

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
@@ -7,7 +7,7 @@ class Resource implements XmlSerializable {
     String path
     Boolean physicalSourceCode
 
-    ConfigurablePathSet pathFilter = new ConfigurablePathSet()
+    ConfigurablePathSet pathFilter = new ConfigurablePathSet('filter')
 
     Resource(String path, Boolean physicalSourceCode) {
         this.path = path
@@ -23,24 +23,10 @@ class Resource implements XmlSerializable {
         }
 
         if(!pathFilter.empty) {
-            Node filter = new Node(node, 'filter')
-            appendPathSetToNode(filter, pathFilter)
+            pathFilter.saveToXml(node)
         }
 
         return node
     }
 
-    /**
-     * Appends the elements of the ConfigurablePathSet as &lt;include&gt; or &lt;exclude&gt; tag
-     * @param filterNode
-     * @param pathSet
-     */
-    protected void appendPathSetToNode(Node filterNode, ConfigurablePathSet pathSet) {
-        pathSet.includedPaths.each { String path ->
-            new Node(filterNode, 'include', [path: path])
-        }
-        pathSet.excludedPaths.each { String path ->
-            new Node(filterNode, 'exclude', [path: path])
-        }
-    }
 }

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Resource.groovy
@@ -7,7 +7,7 @@ class Resource implements XmlSerializable {
     String path
     Boolean physicalSourceCode
 
-    ConfigurablePathSet filter = new ConfigurablePathSet()
+    ConfigurablePathSet pathFilter = new ConfigurablePathSet()
 
     Resource(String path, Boolean physicalSourceCode) {
         this.path = path
@@ -17,11 +17,31 @@ class Resource implements XmlSerializable {
     @Override
     def saveToXml(Node root) {
         Map attributes = [path: path]
+        Node node = new Node(root, 'resource-root', attributes)
 
         if (physicalSourceCode) {
             attributes.'use-physical-code-source' = true
         }
 
-        return new Node(root, 'resource-root', attributes)
+        if(!pathFilter.empty) {
+            Node filter = new Node(node, 'filter')
+            appendPathSetToNode(filter, pathFilter)
+        }
+
+        return node
+    }
+
+    /**
+     * Appends the elements of the ConfigurablePathSet as &lt;include&gt; or &lt;exclude&gt; tag
+     * @param filterNode
+     * @param pathSet
+     */
+    protected void appendPathSetToNode(Node filterNode, ConfigurablePathSet pathSet) {
+        pathSet.includedPaths.each { String path ->
+            new Node(filterNode, 'include', [path: path])
+        }
+        pathSet.excludedPaths.each { String path ->
+            new Node(filterNode, 'exclude', [path: path])
+        }
     }
 }

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Subdeployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Subdeployment.groovy
@@ -16,6 +16,7 @@
 
 package com.github.mamohr.gradle.deploymentstructure.model
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Named
 
 /**
@@ -25,6 +26,7 @@ class Subdeployment extends Deployment implements Named, XmlSerializable {
     static String EXTENSION_NAME = 'jbossSubdeployment'
 
     String name
+    private final ConfigurablePathSet resourceFilter = new ConfigurablePathSet()
 
     public Subdeployment(String name) {
         this.name = name
@@ -34,11 +36,49 @@ class Subdeployment extends Deployment implements Named, XmlSerializable {
 
     }
 
+
+    /**
+     * Filters resource with include and exclude directives
+     * @param cl
+     */
+    void resourceFilter(@DelegatesTo(ConfigurablePathSet) Closure cl) {
+        cl.delegate = resourceFilter
+        cl.resolveStrategy = Closure.DELEGATE_FIRST
+        cl()
+    }
+
     @Override
     def saveToXml(Node node) {
         Node subdeployment = super.saveToXml(node)
         subdeployment.attributes().name = name
+
+        if(!resourceFilter.empty) {
+            Node resources = (Node)subdeployment.find{ it.name() == 'resources' }
+            Node filter = new Node(resources, 'filter')
+
+            // Resource tag not found, thus no resources are declared and a filter is useless
+            if(!resources) {
+                throw new InvalidUserDataException('Cannot apply resource filter on empty resource set')
+            }
+
+            appendResourceFilterToNode(filter, resourceFilter)
+        }
+
         return subdeployment
+    }
+
+    /**
+     * Appends the elements of the ConfigurablePathSet as &lt;include&gt; or &lt;exclude&gt; tag
+     * @param filterNode
+     * @param pathSet
+     */
+    protected void appendResourceFilterToNode(Node filterNode, ConfigurablePathSet pathSet) {
+        pathSet.includedPaths.each { String path ->
+            new Node(filterNode, 'include', [path: path])
+        }
+        pathSet.excludedPaths.each { String path ->
+            new Node(filterNode, 'exclude', [path: path])
+        }
     }
 
     @Override

--- a/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Subdeployment.groovy
+++ b/src/main/groovy/com/github/mamohr/gradle/deploymentstructure/model/Subdeployment.groovy
@@ -26,7 +26,6 @@ class Subdeployment extends Deployment implements Named, XmlSerializable {
     static String EXTENSION_NAME = 'jbossSubdeployment'
 
     String name
-    private final ConfigurablePathSet resourceFilter = new ConfigurablePathSet()
 
     public Subdeployment(String name) {
         this.name = name
@@ -36,49 +35,12 @@ class Subdeployment extends Deployment implements Named, XmlSerializable {
 
     }
 
-
-    /**
-     * Filters resource with include and exclude directives
-     * @param cl
-     */
-    void resourceFilter(@DelegatesTo(ConfigurablePathSet) Closure cl) {
-        cl.delegate = resourceFilter
-        cl.resolveStrategy = Closure.DELEGATE_FIRST
-        cl()
-    }
-
     @Override
     def saveToXml(Node node) {
         Node subdeployment = super.saveToXml(node)
         subdeployment.attributes().name = name
 
-        if(!resourceFilter.empty) {
-            Node resources = (Node)subdeployment.find{ it.name() == 'resources' }
-            Node filter = new Node(resources, 'filter')
-
-            // Resource tag not found, thus no resources are declared and a filter is useless
-            if(!resources) {
-                throw new InvalidUserDataException('Cannot apply resource filter on empty resource set')
-            }
-
-            appendResourceFilterToNode(filter, resourceFilter)
-        }
-
         return subdeployment
-    }
-
-    /**
-     * Appends the elements of the ConfigurablePathSet as &lt;include&gt; or &lt;exclude&gt; tag
-     * @param filterNode
-     * @param pathSet
-     */
-    protected void appendResourceFilterToNode(Node filterNode, ConfigurablePathSet pathSet) {
-        pathSet.includedPaths.each { String path ->
-            new Node(filterNode, 'include', [path: path])
-        }
-        pathSet.excludedPaths.each { String path ->
-            new Node(filterNode, 'exclude', [path: path])
-        }
     }
 
     @Override

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/DeploymentTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/DeploymentTest.groovy
@@ -1,5 +1,7 @@
 package com.github.mamohr.gradle.deploymentstructure.model
 
+import org.apache.ivy.util.XMLHelper
+import org.custommonkey.xmlunit.XMLUnit
 import spock.lang.Specification
 
 import static com.github.mamohr.gradle.deploymentstructure.XmlTestHelper.nodeIsSimilarToString;
@@ -9,10 +11,10 @@ import static com.github.mamohr.gradle.deploymentstructure.XmlTestHelper.nodeIsS
  */
 public class DeploymentTest extends Specification {
 
-    private Deployment deployment
+    private Deployment deployment = new Deployment()
 
     def setupSpec() {
-        deployment = new Deployment()
+        XMLUnit.setIgnoreWhitespace(true)
     }
 
     def 'resources are added'() {

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/DeploymentTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/DeploymentTest.groovy
@@ -1,0 +1,68 @@
+package com.github.mamohr.gradle.deploymentstructure.model
+
+import spock.lang.Specification
+
+import static com.github.mamohr.gradle.deploymentstructure.XmlTestHelper.nodeIsSimilarToString;
+
+/**
+ * Created by cschmidt on 24.02.2017.
+ */
+public class DeploymentTest extends Specification {
+
+    private Deployment deployment
+
+    def setupSpec() {
+        deployment = new Deployment()
+    }
+
+    def 'resources are added'() {
+        String expectedXml =
+                '''<deployment>
+                    <dependencies />
+                    <resources>
+                        <resource-root path="my-library.jar" />
+                        <resource-root path="lib/ext-library.jar" use-physical-code-source="true" />
+                    </resources>
+                </deployment>'''.stripIndent()
+        when:
+        deployment.resource 'my-library.jar'
+        deployment.resource path: 'lib/ext-library.jar', physicalCodeSource: true
+        Node xml = deployment.saveToXml(null)
+        then:
+        nodeIsSimilarToString(xml, expectedXml)
+    }
+
+    def 'resources are added with filter'() {
+        String expectedXml =
+                '''<deployment>
+                    <dependencies />
+                    <resources>
+                        <resource-root path="my-library.jar">
+                            <filter>
+                                <include path="api" />
+                                <exclude path="lib" />
+                            </filter>
+                        </resource-root>
+                        <resource-root path="lib/ext-library.jar" use-physical-code-source="true">
+                            <filter>
+                                <include path="api" />
+                                <exclude path="lib" />
+                            </filter>
+                        </resource-root>
+                    </resources>
+                </deployment>'''.stripIndent()
+        when:
+        deployment.resource 'my-library.jar' {
+            include 'api'
+            exclude 'lib'
+        }
+        deployment.resource(path: 'lib/ext-library.jar', physicalCodeSource: true) {
+            include 'api'
+            exclude 'lib'
+        }
+        Node xml = deployment.saveToXml(null)
+        then:
+        nodeIsSimilarToString(xml, expectedXml)
+    }
+
+}

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/DeploymentTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/DeploymentTest.groovy
@@ -54,7 +54,7 @@ public class DeploymentTest extends Specification {
                     </resources>
                 </deployment>'''.stripIndent()
         when:
-        deployment.resource 'my-library.jar' {
+        deployment.resource('my-library.jar') {
             include 'api'
             exclude 'lib'
         }

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
@@ -155,16 +155,4 @@ class JBossDeploymentStructureTest extends Specification {
         nodeIsSimilarToString(xml, expectedXml)
     }
 
-    def 'throws exception when no resources are present and filter is applied'() {
-        Subdeployment subdeployment = new Subdeployment('my-war.war')
-        when:
-        subdeployment.resourceFilter {
-            include 'api'
-        }
-        structure.subdeployments.add(subdeployment)
-        Node xml = structure.saveToXml(null)
-        then:
-        thrown InvalidUserDataException
-    }
-
 }

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
@@ -125,31 +125,36 @@ class JBossDeploymentStructureTest extends Specification {
         nodeIsSimilarToString(xml, expectedXml)
     }
 
-    def 'resource filter is added to subdeployment'() {
-        Subdeployment subdeployment = new Subdeployment('my-war.war')
+    def 'resources are added with filter'() {
         String expectedXml = '''
             <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
                 <deployment>
-                    <dependencies />
-                </deployment>
-                <sub-deployment name="my-war.war">
-                    <dependencies />
+                    <dependencies/>
                     <resources>
-                        <resource-root path="ext-library.jar"/>
-                        <filter>
-                            <include path="api/123"/>
-                            <exclude path="lib/456"/>
-                        </filter>
+                        <resource-root path="my-library.jar">
+                            <filter>
+                                <include path="api" />
+                                <exclude path="lib" />
+                            </filter>
+                        </resource-root>
+                        <resource-root path="lib/ext-library.jar" use-physical-code-source="true">
+                            <filter>
+                                <include path="api" />
+                                <exclude path="lib" />
+                            </filter>
+                        </resource-root>
                     </resources>
-                </sub-deployment>
+                </deployment>
             </jboss-deployment-structure>'''.stripIndent()
         when:
-        subdeployment.resource 'ext-library.jar'
-        subdeployment.resourceFilter {
-            include 'api/123'
-            exclude 'lib/456'
+        structure.resource 'my-library.jar' {
+            include 'api'
+            exclude 'lib'
         }
-        structure.subdeployments.add(subdeployment)
+        structure.resource(path: 'lib/ext-library.jar', physicalCodeSource: true) {
+            include 'api'
+            exclude 'lib'
+        }
         Node xml = structure.saveToXml(null)
         then:
         nodeIsSimilarToString(xml, expectedXml)

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
@@ -131,16 +131,16 @@ class JBossDeploymentStructureTest extends Specification {
                     <dependencies/>
                     <resources>
                         <resource-root path="my-library.jar">
-                            <filter>
+                            <pathFilter>
                                 <include path="api" />
                                 <exclude path="lib" />
-                            </filter>
+                            </pathFilter>
                         </resource-root>
                         <resource-root path="lib/ext-library.jar" use-physical-code-source="true">
-                            <filter>
+                            <pathFilter>
                                 <include path="api" />
                                 <exclude path="lib" />
-                            </filter>
+                            </pathFilter>
                         </resource-root>
                     </resources>
                 </deployment>

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
@@ -125,6 +125,29 @@ class JBossDeploymentStructureTest extends Specification {
         nodeIsSimilarToString(xml, expectedXml)
     }
 
+    def 'resources are added to subdeployment'() {
+        String expectedXml = '''
+            <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
+                <deployment>
+                    <dependencies/>
+                </deployment>
+                <sub-deployment name="my-war.war">
+                    <dependencies/>
+                    <resources>
+                        <resource-root path="my-library.jar"/>
+                        <resource-root path="lib/ext-library.jar" use-physical-code-source="true"/>
+                    </resources>
+                </sub-deployment>
+            </jboss-deployment-structure>'''.stripIndent()
+        when:
+        Subdeployment subdeployment = structure.subdeployments.create("my-war.war")
+        subdeployment.resource 'my-library.jar'
+        subdeployment.resource path: 'lib/ext-library.jar', physicalCodeSource: true
+        Node xml = structure.saveToXml(null)
+        then:
+        nodeIsSimilarToString(xml, expectedXml)
+    }
+
     def 'resources are added with filter'() {
         String expectedXml = '''
             <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
@@ -17,7 +17,6 @@
 package com.github.mamohr.gradle.deploymentstructure.model
 
 import org.custommonkey.xmlunit.XMLUnit
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer
 import org.gradle.internal.reflect.DirectInstantiator
 import spock.lang.Specification
@@ -120,29 +119,6 @@ class JBossDeploymentStructureTest extends Specification {
         when:
         structure.resource 'my-library.jar'
         structure.resource path: 'lib/ext-library.jar', physicalCodeSource: true
-        Node xml = structure.saveToXml(null)
-        then:
-        nodeIsSimilarToString(xml, expectedXml)
-    }
-
-    def 'resources are added to subdeployment'() {
-        String expectedXml = '''
-            <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
-                <deployment>
-                    <dependencies/>
-                </deployment>
-                <sub-deployment name="my-war.war">
-                    <dependencies/>
-                    <resources>
-                        <resource-root path="my-library.jar"/>
-                        <resource-root path="lib/ext-library.jar" use-physical-code-source="true"/>
-                    </resources>
-                </sub-deployment>
-            </jboss-deployment-structure>'''.stripIndent()
-        when:
-        Subdeployment subdeployment = structure.subdeployments.create("my-war.war")
-        subdeployment.resource 'my-library.jar'
-        subdeployment.resource path: 'lib/ext-library.jar', physicalCodeSource: true
         Node xml = structure.saveToXml(null)
         then:
         nodeIsSimilarToString(xml, expectedXml)

--- a/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
+++ b/src/test/groovy/com/github/mamohr/gradle/deploymentstructure/model/JBossDeploymentStructureTest.groovy
@@ -131,22 +131,22 @@ class JBossDeploymentStructureTest extends Specification {
                     <dependencies/>
                     <resources>
                         <resource-root path="my-library.jar">
-                            <pathFilter>
+                            <filter>
                                 <include path="api" />
                                 <exclude path="lib" />
-                            </pathFilter>
+                            </filter>
                         </resource-root>
                         <resource-root path="lib/ext-library.jar" use-physical-code-source="true">
-                            <pathFilter>
+                            <filter>
                                 <include path="api" />
                                 <exclude path="lib" />
-                            </pathFilter>
+                            </filter>
                         </resource-root>
                     </resources>
                 </deployment>
             </jboss-deployment-structure>'''.stripIndent()
         when:
-        structure.resource 'my-library.jar' {
+        structure.resource('my-library.jar') {
             include 'api'
             exclude 'lib'
         }


### PR DESCRIPTION
Hi Mario,

I would like to implement resource filtering, before releasing a new version. At first I did an implementation in the `Deployment` class, but got this error: [Integration Test Failure](https://travis-ci.org/jazzschmidt/jboss-deployment-structure/jobs/204634943#L187-L191)

I thought it was not permitted directly in the deployment area and moved the whole filtering part into the `Subdeployment` class, which then lead to the same error (actually shown in the build log above).

According to [this example xml](https://kb.novaordis.com/index.php/Jboss-deployment-structure.xml), the filter tag is permitted at least in the resource tag of subdeployments. A quick look into the xml scheme revealed, that the filter tag is not bounded to the subdeployment. Can you help me out with this one? Am I missing something obvious?